### PR TITLE
Add planning questions and coding guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,44 @@ This document defines the agent behavior for using Codex within this repository.
 * Reflect only the current state—remove or archive outdated entries.
 * Maintain chronological clarity: new features append to the bottom of their module section.
 
+## Coding Standards & Guidelines
+
+- **Project Structure & Templates**
+  - All Python scripts follow `template.py` layout: shebang, sections (Imports → Logging → Globals → Classes/Functions → `main()`)
+  - No inline scripts; use `if __name__ == "__main__":` entry point
+- **Logging & Monitoring**
+  - Use `log_message(level, msg)` helper for every operational message
+  - Log exceptions with full traceback at `ERROR` level
+  - Enqueue logs for GUI display when applicable
+- **Error Handling & Validation**
+  - Wrap PST reads and parsing in `try/except`
+  - Validate input paths, memory usage, and PST integrity before processing
+  - Fail gracefully with user-friendly messages in GUI or console
+- **Dependency Minimization**
+  - Avoid heavy third-party libraries; prefer built-in modules (`os`, `re`, `email`)
+  - If PST parsing requires external library, wrap it behind a thin abstraction
+- **Signature Extraction Module**
+  - Expose a clean API: `extract_signatures(pst_path: str) → Iterator[Signature]`
+  - Signature objects must normalize whitespace and HTML tags
+  - Pluggable heuristics: allow adding new detection rules via a registry
+- **Deduplication Module**
+  - Provide `dedupe_signatures(signatures: Iterable[Signature]) → List[Signature]`
+  - Configurable fuzzy matching thresholds
+- **Search & Indexing**
+  - Abstract backend behind `SearchIndex` interface (`add()`, `query()`)
+  - Allow swapping SQLite FTS or other engine without code changes
+- **Tkinter GUI Guidelines**
+  - Follow `TemplateApp` styling: consistent frames, fonts, colors
+  - Disable “Start Extraction” button while a run is active
+  - Display real-time progress and logs in a scrollable text widget
+- **Threading & Responsiveness**
+  - Offload PST parsing and indexing to a background thread
+  - Use `stop_event` to signal cancellation; re-enable UI controls on stop
+- **Documentation & Testing**
+  - Docstrings for every public function/class
+  - Unit tests for extraction and deduplication logic
+  - End-to-end tests with sample PST files
+
 ---
 
 *This file is intended for internal use by Codex-powered agents to maintain a living project map.*

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -8,10 +8,48 @@
 - **Files**
   - `README.md` — project overview
   - `AGENTS.md` — Codex automation rules
-  - `PROJECTMAP.md` — this project map
+  - `PROJECTMAP.md` — project map and planning questions
 
 ### Signature Recovery (planned)
 - **Features**
   - Core algorithms for recovering signature blocks (**Planned**)
 - **Dependencies**
   - None yet
+
+## Open Planning Questions
+
+- **Data Sources & Scale**
+  - Typical size, number, and location of `.pst` files to process
+  - Expected volume of emails (e.g. millions of messages)
+  - Target performance (e.g. signatures extracted per hour)
+- **Extraction Logic & Heuristics**
+  - Definition of a "signature block" (lines in plain text, HTML, attachments?)
+  - Rules for start/end detection (e.g. detect delimiter lines like "—" or "Regards,")
+  - Expected false-positive rate and how to tune heuristics
+- **Deduplication Criteria**
+  - What constitutes a duplicate signature (exact text match, fuzzy match, normalized fields)
+  - Tolerance for minor variations (e.g. different titles, phone formats)
+- **Storage & Search Backend**
+  - Target searchable format (SQLite, full-text index, Elasticsearch, etc.)
+  - Query patterns (search by name, company, domain)
+  - Retention and archival policies
+- **CLI vs. GUI Requirements**
+  - Will there be a desktop GUI for ad-hoc extraction?
+  - Command-line support and batch scheduling
+- **Platform & Dependencies**
+  - Supported OSes (Windows, Linux, macOS)
+  - Python version constraints (3.8+?)
+  - Allowed third-party modules (pst-parser, regex libraries)
+- **Error Handling & Logging**
+  - Failure modes (corrupt PST, malformed messages)
+  - Retry strategies and reporting
+  - Log verbosity levels and log file rotation policy
+- **Security & Privacy**
+  - Handling of sensitive data (PII) in signatures
+  - Access controls on extracted data
+- **Timeline & Milestones**
+  - Prototype extraction engine
+  - Deduplication module
+  - Search/indexing integration
+  - GUI proof-of-concept
+  - Testing and performance tuning


### PR DESCRIPTION
## Summary
- expand `AGENTS.md` with coding standards and guidelines
- outline open planning questions in `PROJECTMAP.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68755f5728dc8331b8614c3619251f75