### PR TITLE
Implement PST parser and add tests

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -12,12 +12,12 @@
 
 ### Signature Recovery Core
 - **Features**
-  - PST parsing interface (**Planned**)
+  - PST parsing interface (**Complete**)
   - Signature extraction heuristics (**In Progress**)
   - Deduplication utilities (**Complete**)
 - **Files**
-  - `signature_recovery/core/models.py` — dataclass for signature records
-  - `signature_recovery/core/pst_parser.py` — stub PST parser
+  - `signature_recovery/core/models.py` — dataclass for signature records and messages (**Complete**)
+  - `signature_recovery/core/pst_parser.py` — streaming PST parser (**Complete**)
   - `signature_recovery/core/extractor.py` — extraction logic with heuristics and HTML normalization (**Complete**)
   - `signature_recovery/core/deduplicator.py` — fuzzy dedupe implementation (**Complete**)
 
@@ -44,9 +44,11 @@
 ### Tests
 - **Features**
   - Unit tests for extractor and deduplicator (**Complete**)
+  - PST parser tests (**Complete**)
 - **Files**
   - `tests/test_extractor.py` — extraction tests
   - `tests/test_deduplicator.py` — deduplication tests (**Complete**)
+  - `tests/test_pst_parser.py` — PST parser tests (**Complete**)
   - `tests/fixtures/html_bodies/` — sample HTML messages for extractor tests (**Complete**)
 
 ## Open Planning Questions

--- a/signature_recovery/core/models.py
+++ b/signature_recovery/core/models.py
@@ -22,3 +22,12 @@ class Signature:
     def _normalize(text: str) -> str:
         clean = re.sub(r"\s+", " ", text)
         return clean.strip().lower()
+
+
+@dataclass
+class Message:
+    """Represents one email message extracted from a PST."""
+
+    body: str
+    msg_id: str
+    timestamp: float

--- a/signature_recovery/core/pst_parser.py
+++ b/signature_recovery/core/pst_parser.py
@@ -1,22 +1,87 @@
 #!/usr/bin/env python3
-"""PST parsing utilities."""
+"""
+pst_parser.py
+-------------
+PSTParser streams email messages out of a .pst file, yielding
+Message objects with body, msg_id, and timestamp.
+"""
 
+import os
 import logging
-from typing import Iterator, Tuple
+import time
+from typing import Iterator
 
+from signature_recovery.core.models import Message
+from template import log_message  # our helper
 
-def log_message(level: int, msg: str) -> None:
-    """Simple logging helper."""
-    logging.log(level, msg)
+logger = logging.getLogger("PSTParser")
+logger.setLevel(logging.INFO)
 
 
 class PSTParser:
-    """Streams messages from a PST file. Placeholder implementation."""
+    """Abstraction over a PST file. Yields Message instances."""
 
     def __init__(self, pst_path: str) -> None:
-        self.pst_path = pst_path
+        """Initialize with path to the PST file."""
+        if not os.path.isfile(pst_path):
+            log_message("error", f"PST file not found: {pst_path}")
+            raise FileNotFoundError(f"PST file not found: {pst_path}")
 
-    def messages(self) -> Iterator[Tuple[str, str]]:
-        """Yield message_id and body text. Currently stubbed."""
-        log_message(logging.DEBUG, "PSTParser.messages called - stub")
-        return iter([])
+        try:
+            import pypff
+        except ImportError as e:
+            log_message("critical", "pypff library is required for PST parsing")
+            raise
+
+        self._pst = pypff.file()
+        self._pst.open(pst_path)
+        log_message("info", f"Opened PST file: {pst_path}")
+
+    def iter_messages(self) -> Iterator[Message]:
+        """Traverse all folders and messages in the PST."""
+        root = self._pst.get_root_folder()
+        for folder in self._walk_folders(root):
+            for i in range(folder.get_number_of_sub_messages()):
+                try:
+                    item = folder.get_sub_message(i)
+                    body = item.plain_text_body or item.html_body or ""
+                    msg_id = (
+                        item.identifier.hex()
+                        if hasattr(item, "identifier")
+                        else str(time.time())
+                    )
+                    timestamp = item.client_submit_time or time.time()
+                    yield Message(body=body, msg_id=msg_id, timestamp=timestamp)
+                except Exception as e:
+                    log_message(
+                        "warning",
+                        f"Failed to read message #{i} in folder {folder.name}: {e}",
+                    )
+                    continue
+
+    def _walk_folders(self, folder) -> Iterator:
+        """Recursively walk subfolders."""
+        yield folder
+        for i in range(folder.get_number_of_sub_folders()):
+            sub = folder.get_sub_folder(i)
+            yield from self._walk_folders(sub)
+
+
+def main() -> None:
+    """Quick test harness."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Test PSTParser")
+    parser.add_argument("pst_file", help="Path to PST file")
+    args = parser.parse_args()
+    parser_obj = PSTParser(args.pst_file)
+    count = 0
+    for msg in parser_obj.iter_messages():
+        print(f"{msg.msg_id} @ {msg.timestamp}")
+        count += 1
+        if count >= 5:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/template.py
+++ b/template.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Shared helpers used across modules."""
+
+import logging
+from typing import Union
+
+
+def log_message(level: Union[int, str], msg: str) -> None:
+    """Log ``msg`` at the specified ``level``.
+
+    ``level`` can be a logging level constant or a case-insensitive
+    string like "info" or "warning".
+    """
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    logging.log(level, msg)
+

--- a/tests/test_pst_parser.py
+++ b/tests/test_pst_parser.py
@@ -1,0 +1,31 @@
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+from signature_recovery.core.pst_parser import PSTParser
+
+
+def test_nonexistent_file():
+    with pytest.raises(FileNotFoundError):
+        PSTParser("/no/such/file.pst")
+
+
+def test_missing_pypff(monkeypatch, tmp_path):
+    # create dummy pst file so path check passes
+    pst = tmp_path / "dummy.pst"
+    pst.write_text("dummy")
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pypff":
+            raise ImportError("not installed")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError):
+        PSTParser(str(pst))
+


### PR DESCRIPTION
## Summary
- implement streaming `PSTParser` using pypff
- add `Message` dataclass for parsed emails
- create shared `log_message` helper
- test PST parser error cases
- update project map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768b6407f48331aa09ec5258761145