### PR TITLE
Add batch CLI options and metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -q
+      - name: CLI help flags
+        run: python -m signature_recovery.cli.main --help | grep "threads"

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -33,7 +33,7 @@
 - **Features**
   - Headless extraction entry point (**Complete**)
 - **Files**
-  - `signature_recovery/cli/main.py` — argparse interface
+  - `signature_recovery/cli/main.py` — argparse interface with batch-processing flags and metrics (**Complete**)
 
 ### GUI
 - **Features**
@@ -57,6 +57,10 @@
   - Typical size, number, and location of `.pst` files to process
   - Expected volume of emails (e.g. millions of messages)
   - Target performance (e.g. signatures extracted per hour)
+- **Performance & Scaling**
+  - Target throughput (messages/sec) per thread
+  - Memory footprint per batch size
+  - Desired latency for small vs. large PSTs
 - **Extraction Logic & Heuristics**
   - Definition of a "signature block" (lines in plain text, HTML, attachments?)
   - Rules for start/end detection (e.g. detect delimiter lines like "—" or "Regards,")

--- a/signature_recovery/cli/main.py
+++ b/signature_recovery/cli/main.py
@@ -2,19 +2,74 @@
 """Command-line interface for signature recovery."""
 
 import argparse
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
 
-from ..index.indexer import index_pst
+from ..core.extractor import SignatureExtractor
+from ..core.pst_parser import PSTParser
+from ..core.models import Message, Signature
+from ..index.indexer import add_batch
 from ..index.search_index import SQLiteFTSIndex
+from template import log_message
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Recover signatures from a PST")
     parser.add_argument("--input", required=True, help="Path to PST file")
-    parser.add_argument("--output", required=True, help="SQLite index path")
+    parser.add_argument("--output", required=True, dest="index_db", help="Path to SQLite FTS index")
+    parser.add_argument("--threads", type=int, default=1, help="Number of worker threads")
+    parser.add_argument("--batch-size", type=int, default=1000, help="Messages per commit")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity")
+    parser.add_argument("--metrics", action="store_true", help="Print timing statistics")
     args = parser.parse_args()
 
-    index = SQLiteFTSIndex(args.output)
-    index_pst(args.input, index)
+    level = logging.WARNING
+    if args.verbose == 1:
+        level = logging.INFO
+    elif args.verbose >= 2:
+        level = logging.DEBUG
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+    parser_obj = PSTParser(args.input)
+    extractor = SignatureExtractor()
+    indexer = SQLiteFTSIndex(args.index_db)
+
+    start = time.time()
+    total_messages = 0
+    total_signatures = 0
+    batch: List[Signature] = []
+
+    def worker(msg: Message) -> Signature | None:
+        try:
+            return extractor.extract_signature(msg.body, msg.msg_id, msg.timestamp)
+        except Exception:
+            log_message(logging.ERROR, f"Failed to process message {msg.msg_id}",)
+            logging.exception("worker error")
+            return None
+
+    with ThreadPoolExecutor(max_workers=args.threads) as pool:
+        for sig in pool.map(worker, parser_obj.iter_messages()):
+            total_messages += 1
+            if sig:
+                batch.append(sig)
+                total_signatures += 1
+            if len(batch) >= args.batch_size:
+                add_batch(indexer, batch)
+                log_message(logging.INFO, f"Committed {len(batch)} signatures")
+                batch.clear()
+
+    if batch:
+        add_batch(indexer, batch)
+        log_message(logging.INFO, f"Committed {len(batch)} signatures")
+
+    elapsed = time.time() - start
+    if args.metrics:
+        msg_rate = total_messages / elapsed if elapsed else 0
+        sig_rate = total_signatures / elapsed if elapsed else 0
+        print(f"Processed {total_messages} messages in {elapsed:.2f} seconds ({msg_rate:.0f} msg/sec)")
+        print(f"Extracted {total_signatures} signatures ({sig_rate:.0f} sig/sec)")
 
 
 if __name__ == "__main__":

--- a/signature_recovery/index/indexer.py
+++ b/signature_recovery/index/indexer.py
@@ -6,7 +6,13 @@ from typing import Iterable
 
 from ..core.extractor import SignatureExtractor
 from ..core.pst_parser import PSTParser, log_message
+from ..core.models import Signature
 from .search_index import SearchIndex
+
+
+def add_batch(index: SearchIndex, signatures: Iterable[Signature]) -> None:
+    """Add a batch of signatures to the index."""
+    index.add_batch(signatures)
 
 
 def index_pst(pst_path: str, index: SearchIndex) -> None:
@@ -14,7 +20,7 @@ def index_pst(pst_path: str, index: SearchIndex) -> None:
     log_message(logging.INFO, f"Indexing {pst_path}")
     parser = PSTParser(pst_path)
     extractor = SignatureExtractor()
-    for msg_id, body in parser.messages():
-        sig = extractor.extract_signature(body, msg_id)
+    for msg in parser.iter_messages():
+        sig = extractor.extract_signature(msg.body, msg.msg_id, msg.timestamp)
         if sig:
             index.add(sig)


### PR DESCRIPTION
## Summary
- support batch processing in CLI and threadpool
- track throughput metrics in CLI
- add add_batch to search index
- fix indexer index_pst
- add CI smoke test for --threads help
- update project map with new CLI status and planning notes

## Testing
- `pytest -q`
- `python -m signature_recovery.cli.main --help | grep "threads"`

------
https://chatgpt.com/codex/tasks/task_e_6876a05b29d883319f9529c481eefc2f