### PR TITLE
Add GUI search & CLI query with benchmarks

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -32,6 +32,7 @@
 ### CLI
 - **Features**
   - Headless extraction entry point (**Complete**)
+  - Expose `query` subcommand for on-demand search (**Planned**)
 - **Files**
   - `signature_recovery/cli/main.py` — argparse interface with batch-processing flags and metrics (**Complete**)
 
@@ -40,11 +41,13 @@
   - Basic Tkinter application (**Complete**)
 - **Files**
   - `signature_recovery/gui/app.py` — minimal GUI
+  - `signature_recovery/gui/app.py` — add search panel and results display (**Planned**)
 
 ### Tests
 - **Features**
   - Unit tests for extractor and deduplicator (**Complete**)
   - PST parser tests (**Complete**)
+  - Benchmark tests for performance and index validity (**Planned**)
 - **Files**
   - `tests/test_extractor.py` — extraction tests
   - `tests/test_deduplicator.py` — deduplication tests (**Complete**)
@@ -92,3 +95,9 @@
   - Search/indexing integration
   - GUI proof-of-concept
   - Testing and performance tuning
+- **Search Functionality**
+  - Query syntax (full-text vs. fielded search)
+  - UI/UX requirements (pagination, sorting)
+- **Benchmark Targets**
+  - Minimum acceptable throughput
+  - Index size growth per signature

--- a/signature_recovery/cli/main.py
+++ b/signature_recovery/cli/main.py
@@ -17,12 +17,21 @@ from template import log_message
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Recover signatures from a PST")
-    parser.add_argument("--input", required=True, help="Path to PST file")
-    parser.add_argument("--output", required=True, dest="index_db", help="Path to SQLite FTS index")
-    parser.add_argument("--threads", type=int, default=1, help="Number of worker threads")
-    parser.add_argument("--batch-size", type=int, default=1000, help="Messages per commit")
-    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity")
-    parser.add_argument("--metrics", action="store_true", help="Print timing statistics")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    extract = sub.add_parser("extract", help="Index signatures from a PST")
+    extract.add_argument("--input", required=True, help="Path to PST file")
+    extract.add_argument("--output", required=True, dest="index_db", help="Path to SQLite FTS index")
+    extract.add_argument("--threads", type=int, default=1, help="Number of worker threads")
+    extract.add_argument("--batch-size", type=int, default=1000, help="Messages per commit")
+    extract.add_argument("--metrics", action="store_true", help="Print timing statistics")
+    extract.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity")
+
+    query_p = sub.add_parser("query", help="Search an existing index")
+    query_p.add_argument("--index", required=True, help="Path to SQLite FTS index")
+    query_p.add_argument("--q", required=True, help="Search query")
+    query_p.add_argument("-v", "--verbose", action="count", default=0, help="Increase logging verbosity")
+
     args = parser.parse_args()
 
     level = logging.WARNING
@@ -32,44 +41,55 @@ def main() -> None:
         level = logging.DEBUG
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
 
-    parser_obj = PSTParser(args.input)
-    extractor = SignatureExtractor()
-    indexer = SQLiteFTSIndex(args.index_db)
+    if args.command == "extract":
+        parser_obj = PSTParser(args.input)
+        extractor = SignatureExtractor()
+        indexer = SQLiteFTSIndex(args.index_db)
 
-    start = time.time()
-    total_messages = 0
-    total_signatures = 0
-    batch: List[Signature] = []
+        start = time.time()
+        total_messages = 0
+        total_signatures = 0
+        batch: List[Signature] = []
 
-    def worker(msg: Message) -> Signature | None:
-        try:
-            return extractor.extract_signature(msg.body, msg.msg_id, msg.timestamp)
-        except Exception:
-            log_message(logging.ERROR, f"Failed to process message {msg.msg_id}",)
-            logging.exception("worker error")
-            return None
+        def worker(msg: Message) -> Signature | None:
+            try:
+                return extractor.extract_signature(msg.body, msg.msg_id, msg.timestamp)
+            except Exception:
+                log_message(logging.ERROR, f"Failed to process message {msg.msg_id}")
+                logging.exception("worker error")
+                return None
 
-    with ThreadPoolExecutor(max_workers=args.threads) as pool:
-        for sig in pool.map(worker, parser_obj.iter_messages()):
-            total_messages += 1
-            if sig:
-                batch.append(sig)
-                total_signatures += 1
-            if len(batch) >= args.batch_size:
-                add_batch(indexer, batch)
-                log_message(logging.INFO, f"Committed {len(batch)} signatures")
-                batch.clear()
+        with ThreadPoolExecutor(max_workers=args.threads) as pool:
+            for sig in pool.map(worker, parser_obj.iter_messages()):
+                total_messages += 1
+                if sig:
+                    batch.append(sig)
+                    total_signatures += 1
+                if len(batch) >= args.batch_size:
+                    add_batch(indexer, batch)
+                    log_message(logging.INFO, f"Committed {len(batch)} signatures")
+                    batch.clear()
 
-    if batch:
-        add_batch(indexer, batch)
-        log_message(logging.INFO, f"Committed {len(batch)} signatures")
+        if batch:
+            add_batch(indexer, batch)
+            log_message(logging.INFO, f"Committed {len(batch)} signatures")
 
-    elapsed = time.time() - start
-    if args.metrics:
-        msg_rate = total_messages / elapsed if elapsed else 0
-        sig_rate = total_signatures / elapsed if elapsed else 0
-        print(f"Processed {total_messages} messages in {elapsed:.2f} seconds ({msg_rate:.0f} msg/sec)")
-        print(f"Extracted {total_signatures} signatures ({sig_rate:.0f} sig/sec)")
+        elapsed = time.time() - start
+        if args.metrics:
+            msg_rate = total_messages / elapsed if elapsed else 0
+            sig_rate = total_signatures / elapsed if elapsed else 0
+            print(
+                f"Processed {total_messages} messages in {elapsed:.2f} seconds ({msg_rate:.0f} msg/sec)"
+            )
+            print(f"Extracted {total_signatures} signatures ({sig_rate:.0f} sig/sec)")
+    elif args.command == "query":
+        indexer = SQLiteFTSIndex(args.index)
+        results = indexer.query(args.q)
+        for sig in results:
+            if args.verbose:
+                print(f"{sig.source_msg_id}\t{sig.timestamp}\t{sig.text}")
+            else:
+                print(sig.text)
 
 
 if __name__ == "__main__":

--- a/signature_recovery/gui/app.py
+++ b/signature_recovery/gui/app.py
@@ -7,6 +7,7 @@ from tkinter import filedialog
 
 from ..index.indexer import index_pst
 from ..index.search_index import SQLiteFTSIndex
+from template import log_message
 
 
 class SignatureApp(tk.Tk):
@@ -17,10 +18,32 @@ class SignatureApp(tk.Tk):
         self.title("Signature Recovery")
         self.geometry("500x400")
 
+        # extraction controls
         self.start_btn = tk.Button(self, text="Start Extraction", command=self.start)
         self.start_btn.pack(pady=10)
-        self.log_text = tk.Text(self, height=15)
+
+        # search controls
+        self.search_frame = tk.Frame(self)
+        tk.Label(self.search_frame, text="Search Signatures:").pack(side=tk.LEFT)
+        self.search_var = tk.StringVar()
+        self.search_entry = tk.Entry(self.search_frame, textvariable=self.search_var)
+        self.search_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
+        self.search_btn = tk.Button(self.search_frame, text="Search", command=self.start_search)
+        self.search_btn.pack(side=tk.LEFT)
+        self.search_frame.pack(fill=tk.X, padx=10, pady=5)
+
+        self.results_list = tk.Listbox(self, height=6)
+        self.results_list.pack(fill=tk.BOTH, expand=True, padx=10)
+        self.results_list.bind("<<ListboxSelect>>", self.show_signature)
+
+        self.sig_text = tk.Text(self, height=6, state=tk.DISABLED)
+        self.sig_text.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+
+        self.log_text = tk.Text(self, height=8)
         self.log_text.pack(fill=tk.BOTH, expand=True)
+
+        self.index: SQLiteFTSIndex | None = None
+        self._results = []
 
     def start(self) -> None:
         pst_path = filedialog.askopenfilename(title="Select PST")
@@ -31,9 +54,44 @@ class SignatureApp(tk.Tk):
         thread.start()
 
     def run_extraction(self, pst_path: str) -> None:
-        index = SQLiteFTSIndex("signatures.db")
-        index_pst(pst_path, index)
+        self.index = SQLiteFTSIndex("signatures.db")
+        index_pst(pst_path, self.index)
         self.start_btn.config(state=tk.NORMAL)
+
+    def start_search(self) -> None:
+        if not self.index:
+            return
+        query = self.search_var.get().strip()
+        if not query:
+            return
+        self.search_btn.config(state=tk.DISABLED)
+        thread = threading.Thread(target=self.run_search, args=(query,), daemon=True)
+        thread.start()
+
+    def run_search(self, query: str) -> None:
+        log_message("info", f"Search started: {query}")
+        results = self.index.query(query) if self.index else []
+        log_message("info", f"Search completed: {len(results)} hits")
+        self._results = results
+        self.after(0, self.populate_results)
+
+    def populate_results(self) -> None:
+        self.results_list.delete(0, tk.END)
+        for sig in self._results:
+            first = sig.text.splitlines()[0] if sig.text else ""
+            label = f"{first} ({sig.timestamp})"
+            self.results_list.insert(tk.END, label)
+        self.search_btn.config(state=tk.NORMAL)
+
+    def show_signature(self, event: tk.Event) -> None:
+        if not self.results_list.curselection():
+            return
+        idx = self.results_list.curselection()[0]
+        sig = self._results[idx]
+        self.sig_text.config(state=tk.NORMAL)
+        self.sig_text.delete("1.0", tk.END)
+        self.sig_text.insert(tk.END, sig.text)
+        self.sig_text.config(state=tk.DISABLED)
 
 
 def main() -> None:

--- a/tests/benchmarks/test_index_size.py
+++ b/tests/benchmarks/test_index_size.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from signature_recovery.index.search_index import SQLiteFTSIndex
+from signature_recovery.core.models import Signature
+
+
+@pytest.fixture(autouse=True)
+def _skip(request):
+    if not request.config.getoption("--benchmark"):
+        pytest.skip("benchmark tests skipped")
+
+
+def test_index_size(tmp_path):
+    db_path = tmp_path / "idx.db"
+    index = SQLiteFTSIndex(str(db_path))
+    signatures = [
+        Signature(text=f"Sig {i}", source_msg_id=str(i), timestamp=str(i))
+        for i in range(5)
+    ]
+    index.add_batch(signatures)
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute("SELECT count(*) FROM signatures")
+    count = cur.fetchone()[0]
+    conn.close()
+    assert count == len(signatures)

--- a/tests/benchmarks/test_large_pst.py
+++ b/tests/benchmarks/test_large_pst.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _skip(request):
+    if not request.config.getoption("--benchmark"):
+        pytest.skip("benchmark tests skipped")
+
+
+def test_large_pst(tmp_path):
+    pst_path = os.environ.get("LARGE_PST_PATH")
+    if not pst_path or not Path(pst_path).is_file():
+        pytest.skip("LARGE_PST_PATH not set")
+    db = tmp_path / "idx.db"
+    cmd = [
+        sys.executable,
+        "-m",
+        "signature_recovery.cli.main",
+        "extract",
+        "--input",
+        pst_path,
+        "--output",
+        str(db),
+        "--metrics",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    rate = 0.0
+    for line in result.stdout.splitlines():
+        if "msg/sec" in line:
+            part = line.rsplit("(", 1)[1]
+            rate = float(part.split()[0])
+            break
+    min_rate = float(os.environ.get("MIN_MSG_RATE", "10"))
+    assert rate >= min_rate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--benchmark", action="store_true", help="run benchmark tests")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from signature_recovery.index.search_index import SQLiteFTSIndex
+from signature_recovery.core.models import Signature
+
+
+def _build_index(tmp_path: Path) -> Path:
+    db = tmp_path / "idx.db"
+    index = SQLiteFTSIndex(str(db))
+    index.add(Signature(text="John Doe\nEngineer", source_msg_id="1", timestamp="123"))
+    index.add(Signature(text="Jane Smith\nManager", source_msg_id="2", timestamp="456"))
+    return db
+
+
+def test_cli_query_basic(tmp_path):
+    db = _build_index(tmp_path)
+    cmd = [sys.executable, "-m", "signature_recovery.cli.main", "query", "--index", str(db), "--q", "John"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "John Doe" in result.stdout
+
+
+def test_cli_query_verbose(tmp_path):
+    db = _build_index(tmp_path)
+    cmd = [
+        sys.executable,
+        "-m",
+        "signature_recovery.cli.main",
+        "query",
+        "--index",
+        str(db),
+        "--q",
+        "Jane",
+        "--verbose",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Jane Smith" in result.stdout
+    assert "2" in result.stdout


### PR DESCRIPTION
## Summary
- add a search panel and result display to the Tkinter GUI
- introduce a `query` subcommand in the CLI for index searching
- implement benchmark tests for large PST processing and index size validation
- provide unit tests for the new CLI query behavior
- document planned search and benchmark work in `PROJECTMAP.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a2a0096483319fa41023c775f2c3