### PR TITLE
Fix runtime deps for API and exporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest
+          pip install pytest flask openpyxl pandas
       - name: Run tests
         run: pytest -q
       - name: CLI help flags

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -51,15 +51,15 @@
 
 ### Exporter
 - **Features**
-  - CSV, JSON, Excel export utilities (**Planned**)
+  - CSV, JSON, Excel export utilities (**Complete**)
 - **Files**
-  - `signature_recovery/exporter.py` — export helpers (**Planned**)
+  - `signature_recovery/exporter.py` — export helpers (**Complete**)
 
 ### API
 - **Features**
-  - REST search endpoint with pagination (**Planned**)
+  - REST search endpoint with pagination (**Complete**)
 - **Files**
-  - `signature_recovery/api.py` — Flask API server (**Planned**)
+  - `signature_recovery/api.py` — Flask API server (**Complete**)
 
 ### Tests
 - **Features**
@@ -67,15 +67,15 @@
   - PST parser tests (**Complete**)
   - Benchmark tests for performance and index validity (**Planned**)
   - Parser metadata tests (**Planned**)
-  - Exporter and API tests (**Planned**)
+  - Exporter and API tests (**Complete**)
 - **Files**
   - `tests/test_extractor.py` — extraction tests
   - `tests/test_deduplicator.py` — deduplication tests (**Complete**)
   - `tests/test_pst_parser.py` — PST parser tests (**Complete**)
   - `tests/fixtures/html_bodies/` — sample HTML messages for extractor tests (**Complete**)
   - `tests/test_parser.py` — metadata parser examples (**Planned**)
-  - `tests/test_exporter.py` — export format tests (**Planned**)
-  - `tests/test_api.py` — REST API tests (**Planned**)
+  - `tests/test_exporter.py` — export format tests (**Complete**)
+  - `tests/test_api.py` — REST API tests (**Complete**)
 
 ### CI Configuration
 - **Features**

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@ setup(
     name="signature_recovery",
     version="0.1.0",
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        "flask>=2.0.0",       # for signature_recovery.api
+        "openpyxl>=3.0.0",    # for signature_recovery.exporter Excel support
+        "pandas>=1.0.0",      # if used for JSON/CSV conversions in exporter
+    ],
     entry_points={
         "console_scripts": [
             "recover-signatures=signature_recovery.cli.main:main",

--- a/signature_recovery/api.py
+++ b/signature_recovery/api.py
@@ -2,7 +2,12 @@
 """Minimal REST API for signature search."""
 
 # Imports
-from flask import Flask, request, jsonify
+try:
+    from flask import Flask, request, jsonify
+except ImportError as e:
+    raise RuntimeError(
+        "Flask is required to run the API. Please install with `pip install flask`."
+    ) from e
 
 from .index.search_index import SQLiteFTSIndex
 from template import log_message

--- a/signature_recovery/exporter.py
+++ b/signature_recovery/exporter.py
@@ -6,7 +6,12 @@ import csv
 import json
 from typing import Iterable
 
-from openpyxl import Workbook
+try:
+    from openpyxl import Workbook
+except ImportError as e:
+    raise RuntimeError(
+        "openpyxl is required for Excel export. Please install with `pip install openpyxl`."
+    ) from e
 
 from .core.models import Signature
 from template import log_message


### PR DESCRIPTION
## Summary
- add Flask, OpenPyXL and pandas deps in `setup.py`
- install those packages in CI
- guard imports in `api.py` and `exporter.py`
- update project map for exporter, API and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b0317c788331ba0418562d94a05c