### PR TITLE
Handle wildcard queries

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -34,8 +34,9 @@
 ### Indexing
 - **Features**
   - Abstract search index interface (**Complete**)
-  - SQLite FTS backend (**Complete**)
-  - None/"*" query returns all rows (**Complete**)
+- SQLite FTS backend (**Complete**)
+- None/"*" query returns all rows (**Complete**)
+- Dynamic WHERE clause for optional filters (**Complete**)
 - **Files**
   - `signature_recovery/index/search_index.py` — index classes
   - `signature_recovery/index/indexer.py` — PST-to-index glue code

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -61,6 +61,7 @@
   - Filters & facets (date range, company, title) (**Complete**)
   - Sort options on columns (**Complete**)
   - "*" or blank search shows all results (**Complete**)
+  - Filter panel seeded on startup (**Complete**)
 - **Files**
   - `signature_recovery/gui/app.py` — full-featured Tkinter application with modular panels; filter listboxes exposed as `company` and `title` (**Complete**)
   - `tests/test_gui.py` — GUI integration tests with event-loop sync (**Complete**)

--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -35,6 +35,7 @@
 - **Features**
   - Abstract search index interface (**Complete**)
   - SQLite FTS backend (**Complete**)
+  - None/"*" query returns all rows (**Complete**)
 - **Files**
   - `signature_recovery/index/search_index.py` — index classes
   - `signature_recovery/index/indexer.py` — PST-to-index glue code
@@ -58,6 +59,7 @@
   - Pagination controls and page size selector (**Complete**)
   - Filters & facets (date range, company, title) (**Complete**)
   - Sort options on columns (**Complete**)
+  - "*" or blank search shows all results (**Complete**)
 - **Files**
   - `signature_recovery/gui/app.py` — full-featured Tkinter application with modular panels; filter listboxes exposed as `company` and `title` (**Complete**)
   - `tests/test_gui.py` — GUI integration tests with event-loop sync (**Complete**)

--- a/signature_recovery/api.py
+++ b/signature_recovery/api.py
@@ -19,7 +19,8 @@ index: SQLiteFTSIndex | None = None
 # Classes/Functions
 @app.route("/search")
 def search() -> object:
-    q = request.args.get("q", "*")
+    q_raw = request.args.get("q", "").strip()
+    q = None if (q_raw == "" or q_raw == "*") else q_raw
     page = int(request.args.get("page", 1))
     size = int(request.args.get("size", 10))
     if not index:

--- a/signature_recovery/cli/main.py
+++ b/signature_recovery/cli/main.py
@@ -161,7 +161,9 @@ def handle_query(args: argparse.Namespace) -> int:
         log_message(logging.ERROR, f"Index not found: {args.index}")
         return 1
     indexer = SQLiteFTSIndex(args.index)
-    results = indexer.query(args.q)
+    q_raw = args.q.strip()
+    q = None if (q_raw == "*" or q_raw == "") else q_raw
+    results = indexer.query(q)
     results = [s for s in results if s.confidence >= args.min_confidence]
     start = (args.page - 1) * args.size
     for sig in results[start : start + args.size]:
@@ -184,7 +186,8 @@ def handle_export(args: argparse.Namespace) -> int:
         log_message(logging.ERROR, f"Index not found: {args.index}")
         return 1
     indexer = SQLiteFTSIndex(args.index)
-    q = args.q or "*"
+    q_raw = (args.q or "").strip()
+    q = None if (q_raw == "*" or q_raw == "") else q_raw
     results = [s for s in indexer.query(q) if s.confidence >= args.min_confidence]
     if args.date_from:
         results = [s for s in results if float(s.timestamp or 0) >= args.date_from]

--- a/signature_recovery/gui/app.py
+++ b/signature_recovery/gui/app.py
@@ -220,14 +220,15 @@ class App(tk.Tk):
     def on_search(self) -> None:
         if not self.index:
             return
-        query = self.search_panel.get_query() or "*"
+        raw_query = self.search_panel.query_var.get().strip()
+        query = None if (raw_query == "*" or raw_query == "") else raw_query
         filters = self.filter_panel.get_filters()
         self.search_panel.disable()
         self.pagination_panel.disable()
         thread = threading.Thread(target=self._search_thread, args=(query, filters), daemon=True)
         thread.start()
 
-    def _search_thread(self, query: str, filters: dict) -> None:
+    def _search_thread(self, query: str | None, filters: dict) -> None:
         log_message("info", f"Search started: {query}")
         results = self.index.query(query) if self.index else []
         results = self._apply_filters(results, filters)

--- a/signature_recovery/index/search_index.py
+++ b/signature_recovery/index/search_index.py
@@ -21,7 +21,7 @@ class SearchIndex:
         for sig in signatures:
             self.add(sig)
 
-    def query(self, q: str) -> List[Signature]:
+    def query(self, q: str | None = None) -> List[Signature]:
         raise NotImplementedError
 
 
@@ -77,10 +77,10 @@ class SQLiteFTSIndex(SearchIndex):
         )
         self.conn.commit()
 
-    def query(self, q: str) -> List[Signature]:
+    def query(self, q: str | None = None) -> List[Signature]:
         log_message(logging.DEBUG, "Querying index")
         cur = self.conn.cursor()
-        if q == "*" or not q.strip():
+        if q is None or q == "*" or not str(q).strip():
             cur.execute(
                 "SELECT source_msg_id, timestamp, text, confidence, metadata FROM signatures"
             )

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -17,7 +17,7 @@ class DummyIndex(SearchIndex):
     def add(self, signature: Signature) -> None:  # pragma: no cover - not used
         pass
 
-    def query(self, q: str, **kwargs):
+    def query(self, q: str | None, **kwargs):
         return self._results
 
 


### PR DESCRIPTION
## Summary
- allow GUI to treat `*` or blank as wildcard by passing `None`
- update SearchIndex interface to accept `None`
- support wildcard search in API and CLI
- adjust GUI test dummy index type hints
- document wildcard search in project map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dd7c24f48331a8b37655ccf01bbb