### PR TITLE
Add confidence scoring features

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -19,12 +19,12 @@
   - Structured signature parser (**Complete**)
   - Metadata parsing (**Complete**)
   - Configuration & Tuning (**Complete**)
-  - Confidence Scoring (**Planned**)
+  - Confidence Scoring (**In Progress**)
   - Metrics & Observability (**Planned**)
 - **Files**
-  - `signature_recovery/core/models.py` — dataclass for signature records and messages (**Complete**)
+  - `signature_recovery/core/models.py` — dataclass for signature records and messages; add `Signature.confidence` (**Complete**)
   - `signature_recovery/core/pst_parser.py` — streaming PST parser (**Complete**)
-  - `signature_recovery/core/extractor.py` — extraction logic with heuristics and HTML normalization (**Complete**)
+  - `signature_recovery/core/extractor.py` — extraction logic with heuristics and HTML normalization; compute and assign confidence (**Complete**)
   - `signature_recovery/core/deduplicator.py` — fuzzy dedupe implementation (**Complete**)
   - `signature_recovery/core/parser.py` — parse names, emails, phones (**Complete**)
   - `signature_recovery/core/config.py` — load YAML configuration (**Complete**)
@@ -93,7 +93,7 @@
   - Pipeline smoke test (**Complete**)
   - Exporter and API tests (**Complete**)
   - CLI integration tests (**Complete**)
-  - Confidence scoring tests (**Planned**)
+  - Confidence scoring tests (**Complete**)
   - Metrics aggregation tests (**Planned**)
 - **Files**
   - `tests/test_extractor.py` — extraction tests
@@ -107,7 +107,7 @@
   - `tests/test_api.py` — REST API tests (**Complete**)
   - `tests/benchmarks/test_large_pst.py` — large PST benchmark (**In Progress**)
   - `tests/benchmarks/test_index_size.py` — index size benchmark (**In Progress**)
-  - `tests/test_confidence.py` — confidence scoring logic tests (**Planned**)
+  - `tests/test_confidence.py` — confidence scoring logic tests (**Complete**)
   - `tests/test_metrics.py` — metrics aggregation tests (**Planned**)
 
 ### CI Configuration

--- a/signature_recovery/api.py
+++ b/signature_recovery/api.py
@@ -23,9 +23,10 @@ def search() -> object:
     q = None if (q_raw == "" or q_raw == "*") else q_raw
     page = int(request.args.get("page", 1))
     size = int(request.args.get("size", 10))
+    min_conf = float(request.args.get("min_confidence", 0.0))
     if not index:
         return jsonify(results=[], total=0)
-    results = index.query(q)
+    results = index.query(q, min_confidence=min_conf)
     start = (page - 1) * size
     end = start + size
     subset = results[start:end]

--- a/signature_recovery/cli/main.py
+++ b/signature_recovery/cli/main.py
@@ -163,12 +163,14 @@ def handle_query(args: argparse.Namespace) -> int:
     indexer = SQLiteFTSIndex(args.index)
     q_raw = args.q.strip()
     q = None if (q_raw == "*" or q_raw == "") else q_raw
-    results = indexer.query(q)
-    results = [s for s in results if s.confidence >= args.min_confidence]
+    results = indexer.query(q, min_confidence=args.min_confidence)
     start = (args.page - 1) * args.size
     for sig in results[start : start + args.size]:
         if args.verbose:
-            print(f"{sig.source_msg_id}\t{sig.timestamp}\t{sig.text}", flush=True)
+            print(
+                f"{sig.source_msg_id}\t{sig.timestamp}\t{sig.confidence:.2f}\t{sig.text}",
+                flush=True,
+            )
         else:
             print(sig.text, flush=True)
     return 0
@@ -188,7 +190,7 @@ def handle_export(args: argparse.Namespace) -> int:
     indexer = SQLiteFTSIndex(args.index)
     q_raw = (args.q or "").strip()
     q = None if (q_raw == "*" or q_raw == "") else q_raw
-    results = [s for s in indexer.query(q) if s.confidence >= args.min_confidence]
+    results = indexer.query(q, min_confidence=args.min_confidence)
     if args.date_from:
         results = [s for s in results if float(s.timestamp or 0) >= args.date_from]
     if args.date_to:

--- a/signature_recovery/core/deduplicator.py
+++ b/signature_recovery/core/deduplicator.py
@@ -49,6 +49,8 @@ def dedupe_signatures(
                         val = getattr(sig.metadata, f.name)
                         if val is not None:
                             setattr(u.metadata, f.name, val)
+                if sig.confidence > u.confidence:
+                    u.confidence = sig.confidence
                 log_message(
                     logging.INFO,
                     f"Merged signature {sig.source_msg_id} into {u.source_msg_id} (ratio={ratio:.2f})",

--- a/signature_recovery/core/extractor.py
+++ b/signature_recovery/core/extractor.py
@@ -172,7 +172,16 @@ class SignatureExtractor:
         text = "\n".join(collected).strip()
         parser = SignatureParser(self.config)
         meta = parser.parse(text)
-        confidence = min(1.0, base_conf + parser.last_score)
+        conf = base_conf
+        if not (meta.email or meta.phone or meta.name):
+            conf = min(conf, 0.5)
+        if meta.email:
+            conf += 0.05
+        if meta.phone:
+            conf += 0.05
+        if meta.name:
+            conf += 0.05
+        confidence = min(conf, 1.0)
         return Signature(
             text=text,
             source_msg_id=message_id,

--- a/signature_recovery/core/models.py
+++ b/signature_recovery/core/models.py
@@ -33,7 +33,7 @@ class Signature:
     metadata:
         Parsed ``SignatureMetadata``.
     confidence:
-        Confidence score between 0.0 and 1.0.
+        Confidence score in the range ``0.0``–``1.0``.
     """
 
     text: str

--- a/signature_recovery/gui/app.py
+++ b/signature_recovery/gui/app.py
@@ -70,6 +70,20 @@ class FilterPanel(tk.LabelFrame):
         self.title.pack(side=tk.LEFT, padx=5)
         lists.pack(fill=tk.X, pady=2)
 
+        conf = tk.Frame(self)
+        tk.Label(conf, text="Min Confidence:").pack(side=tk.LEFT)
+        self.conf_var = tk.DoubleVar(value=0.0)
+        tk.Scale(
+            conf,
+            variable=self.conf_var,
+            from_=0.0,
+            to=1.0,
+            resolution=0.05,
+            orient=tk.HORIZONTAL,
+            length=120,
+        ).pack(side=tk.LEFT, padx=5)
+        conf.pack(fill=tk.X, pady=2)
+
     def set_companies(self, companies) -> None:
         """Populate company filter options."""
         self.company.delete(0, tk.END)
@@ -94,6 +108,7 @@ class FilterPanel(tk.LabelFrame):
             "end": self.end_var.get().strip(),
             "companies": comps,
             "titles": titles,
+            "min_confidence": float(self.conf_var.get()),
         }
 
 
@@ -233,7 +248,8 @@ class App(tk.Tk):
 
     def _search_thread(self, query: str | None, filters: dict) -> None:
         log_message("info", f"Search started: {query}")
-        results = self.index.query(query) if self.index else []
+        min_conf = float(filters.get("min_confidence", 0.0))
+        results = self.index.query(query, min_confidence=min_conf) if self.index else []
         results = self._apply_filters(results, filters)
         self.queue.put(results)
         log_message("info", f"Search completed: {len(results)} hits")

--- a/signature_recovery/index/search_index.py
+++ b/signature_recovery/index/search_index.py
@@ -21,7 +21,7 @@ class SearchIndex:
         for sig in signatures:
             self.add(sig)
 
-    def query(self, q: str | None = None) -> List[Signature]:
+    def query(self, q: str | None = None, *, min_confidence: float = 0.0) -> List[Signature]:
         raise NotImplementedError
 
 
@@ -77,7 +77,7 @@ class SQLiteFTSIndex(SearchIndex):
         )
         self.conn.commit()
 
-    def query(self, q: str | None = None) -> List[Signature]:
+    def query(self, q: str | None = None, *, min_confidence: float = 0.0) -> List[Signature]:
         """Return all matching signatures.
 
         ``q`` may be ``None`` to retrieve every row. ``"*"`` or blank strings are
@@ -96,6 +96,9 @@ class SQLiteFTSIndex(SearchIndex):
         if q:
             where_clauses.append("text MATCH :q")
             params["q"] = q
+        if min_confidence > 0:
+            where_clauses.append("confidence >= :minc")
+            params["minc"] = min_confidence
 
         where_sql = ""
         if where_clauses:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,23 @@ def test_subcommand_help():
         assert "--help" not in res.stderr
 
 
+def test_query_verbose_confidence(tmp_path):
+    db = _build_index(tmp_path)
+    res = _run([
+        sys.executable,
+        "-m",
+        "signature_recovery.cli.main",
+        "query",
+        "--index",
+        str(db),
+        "--q",
+        "John",
+        "--verbose",
+    ])
+    assert "John Doe" in res.stdout
+    assert "0.90" in res.stdout or "0.9" in res.stdout
+
+
 def test_extract_query_export_flow(tmp_path):
     pst = tmp_path / "dummy.pst"
     pst.write_text("dummy")

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,4 +1,10 @@
+import subprocess
+import sys
+from pathlib import Path
+
 from signature_recovery.core.extractor import SignatureExtractor
+from signature_recovery.index.search_index import SQLiteFTSIndex
+from signature_recovery.core.models import Signature
 
 
 def test_confidence_scoring():
@@ -6,14 +12,30 @@ def test_confidence_scoring():
     body = "Hello\n--\nJohn Doe\nEngineer\nACME\njohn@acme.com"
     sig = extractor.extract_from_body(body)
     assert sig is not None
-    assert sig.confidence > 0.9
+    assert sig.confidence >= 0.95
 
 
-def test_confidence_filtering():
-    extractor = SignatureExtractor()
-    body = "Hi\n--\nJane Doe\njane@example.com"
-    sig = extractor.extract_from_body(body)
-    assert sig is not None
-    min_c = sig.confidence + 0.05
-    kept = [s for s in [sig] if s.confidence >= min_c]
-    assert not kept
+def test_confidence_filtering(tmp_path):
+    db = tmp_path / "idx.db"
+    index = SQLiteFTSIndex(str(db))
+    index.add(Signature(text="Low", source_msg_id="1", confidence=0.4))
+    index.add(Signature(text="High", source_msg_id="2", confidence=0.9))
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "signature_recovery.cli.main",
+            "--min-confidence",
+            "0.8",
+            "query",
+            "--index",
+            str(db),
+            "--q",
+            "*",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert "High" in res.stdout
+    assert "Low" not in res.stdout

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -133,3 +133,24 @@ def test_sort_toggle(tmp_path, display):
     names = [r.metadata.name for r in app.results]
     assert names == sorted(names, reverse=True)
     app.close()
+
+
+def test_confidence_slider(tmp_path, display):
+    idx = _build_index(tmp_path, count=2)
+    app = App(idx)
+    app.search_panel.query_var.set("*")
+    app.filter_panel.conf_var.set(0.0)
+    app.on_search()
+    for _ in range(20):
+        app.update()
+        time.sleep(0.05)
+        if app.results:
+            break
+    assert len(app.results) == 2
+    app.filter_panel.conf_var.set(0.75)
+    app.on_search()
+    for _ in range(20):
+        app.update()
+        time.sleep(0.05)
+    assert len(app.results) == 1
+    app.close()


### PR DESCRIPTION
## Summary
- extend Signature model docs for confidence field
- implement confidence boosts in extractor
- carry max confidence when deduplicating
- support min-confidence filtering in search index, CLI and GUI
- expose slider in GUI and show confidence in CLI verbose output
- add tests for confidence logic, CLI output and GUI slider
- update project map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eb34c8848331b65ad6188740e896