### PR TITLE
Implement Metrics Collector

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -20,7 +20,7 @@
   - Metadata parsing (**Complete**)
   - Configuration & Tuning (**Complete**)
   - Confidence Scoring (**In Progress**)
-  - Metrics & Observability (**Planned**)
+  - Metrics & Observability (**In Progress**)
 - **Files**
   - `signature_recovery/core/models.py` — dataclass for signature records and messages; add `Signature.confidence` (**Complete**)
   - `signature_recovery/core/pst_parser.py` — streaming PST parser (**Complete**)
@@ -28,7 +28,7 @@
   - `signature_recovery/core/deduplicator.py` — fuzzy dedupe implementation (**Complete**)
   - `signature_recovery/core/parser.py` — parse names, emails, phones (**Complete**)
   - `signature_recovery/core/config.py` — load YAML configuration (**Complete**)
-  - `signature_recovery/core/metrics.py` — runtime metrics aggregation (**Planned**)
+  - `signature_recovery/core/metrics.py` — runtime metrics aggregation (**In Progress**)
   - `config.example.yaml` — sample configuration (**Complete**)
 
 ### Indexing
@@ -94,7 +94,7 @@
   - Exporter and API tests (**Complete**)
   - CLI integration tests (**Complete**)
   - Confidence scoring tests (**Complete**)
-  - Metrics aggregation tests (**Planned**)
+  - Metrics aggregation tests (**Complete**)
 - **Files**
   - `tests/test_extractor.py` — extraction tests
   - `tests/test_deduplicator.py` — deduplication tests (**Complete**)
@@ -108,7 +108,7 @@
   - `tests/benchmarks/test_large_pst.py` — large PST benchmark (**In Progress**)
   - `tests/benchmarks/test_index_size.py` — index size benchmark (**In Progress**)
   - `tests/test_confidence.py` — confidence scoring logic tests (**Complete**)
-  - `tests/test_metrics.py` — metrics aggregation tests (**Planned**)
+  - `tests/test_metrics.py` — metrics aggregation tests (**Complete**)
 
 ### CI Configuration
 - **Features**

--- a/signature_recovery/cli/main.py
+++ b/signature_recovery/cli/main.py
@@ -16,7 +16,7 @@ from .. import __version__
 
 from ..core.extractor import SignatureExtractor
 from ..core.deduplicator import dedupe_signatures
-from ..core.metrics import Metrics
+from ..core.metrics import MetricsCollector, MessageMetric
 from ..core.models import Message, Signature
 from ..core.pst_parser import PSTParser
 from ..exporter import export_to_csv, export_to_json, export_to_excel
@@ -96,26 +96,29 @@ def handle_extract(args: argparse.Namespace) -> int:
 
     extractor = SignatureExtractor()
     indexer = SQLiteFTSIndex(args.index)
-    metrics = Metrics()
+    metrics = MetricsCollector()
     start = time.time()
     batch: List[Signature] = []
 
     def worker(msg: Message) -> Signature | None:
-        begin = time.time()
+        start_ts = time.time()
         try:
             sig = extractor.extract_signature(msg.body, msg.msg_id, msg.timestamp)
         except Exception as e:  # pragma: no cover - unexpected parse errors
             log_message(logging.ERROR, f"Failed to process message {msg.msg_id}")
             logging.exception("worker error")
-            metrics.record(msg.msg_id, False, 0.0, len(msg.body.splitlines()), 0.0)
+            metrics.record(
+                MessageMetric(msg_id=msg.msg_id, extracted=False, confidence=0.0, time_ms=0.0)
+            )
             return None
-        elapsed_ms = (time.time() - begin) * 1000
+        duration_ms = (time.time() - start_ts) * 1000
         metrics.record(
-            msg.msg_id,
-            sig is not None,
-            sig.confidence if sig else 0.0,
-            len(msg.body.splitlines()),
-            elapsed_ms,
+            MessageMetric(
+                msg_id=msg.msg_id,
+                extracted=sig is not None,
+                confidence=sig.confidence if sig else 0.0,
+                time_ms=duration_ms,
+            )
         )
         return sig
 
@@ -135,17 +138,18 @@ def handle_extract(args: argparse.Namespace) -> int:
         log_message(logging.INFO, f"Committed {len(uniques)} signatures")
 
     elapsed = time.time() - start
-    summary = metrics.summary()
+    summary = metrics.summarize()
     if args.metrics:
-        msg_rate = summary["messages"] / elapsed if elapsed else 0
-        sig_rate = summary["signatures_found"] / elapsed if elapsed else 0
+        msg_rate = summary["total_messages"] / elapsed if elapsed else 0
+        sig_rate = summary["signatures_extracted"] / elapsed if elapsed else 0
         print(
-            f"Processed {summary['messages']} messages in {elapsed:.2f} seconds ({msg_rate:.0f} msg/sec)")
+            f"Processed {summary['total_messages']} messages in {elapsed:.2f} seconds ({msg_rate:.0f} msg/sec)"
+        )
         print(
-            f"Extracted {summary['signatures_found']} signatures ({sig_rate:.0f} sig/sec), avg conf {summary['avg_confidence']:.2f}")
+            f"Extracted {summary['signatures_extracted']} signatures ({sig_rate:.0f} sig/sec), avg conf {summary['average_confidence']:.2f}"
+        )
     if args.dump_metrics:
-        with open(args.dump_metrics, "w", encoding="utf-8") as fh:
-            json.dump(summary, fh, indent=2)
+        metrics.dump(args.dump_metrics)
     return 0
 
 

--- a/signature_recovery/core/metrics.py
+++ b/signature_recovery/core/metrics.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Metrics collection utilities."""
+"""Runtime metrics collection utilities."""
 
 # Imports
 import json
-from dataclasses import dataclass
+import threading
+import time
+from dataclasses import dataclass, asdict
+from typing import List
+
 from template import log_message
 
 # Logging
@@ -13,56 +17,58 @@ from template import log_message
 # Classes/Functions
 
 @dataclass
-class Metrics:
-    """Accumulates processing metrics."""
+class MessageMetric:
+    """Per-message metric record."""
 
-    total_messages: int = 0
-    signatures_found: int = 0
-    total_time_ms: float = 0.0
-    total_confidence: float = 0.0
+    msg_id: str
+    extracted: bool
+    confidence: float
+    time_ms: float
 
-    def record(
-        self, msg_id: str, extracted: bool, confidence: float, num_lines: int, time_ms: float
-    ) -> None:
-        """Log message metrics and update counters."""
-        log_message(
-            "info",
-            json.dumps(
-                {
-                    "msg_id": msg_id,
-                    "extracted": extracted,
-                    "confidence": round(confidence, 2),
-                    "num_lines": num_lines,
-                    "time_ms": round(time_ms, 2),
-                }
-            ),
-        )
-        self.total_messages += 1
-        self.total_time_ms += time_ms
-        if extracted:
-            self.signatures_found += 1
-            self.total_confidence += confidence
 
-    def summary(self) -> dict:
-        """Return aggregated metrics."""
-        avg_time = self.total_time_ms / self.total_messages if self.total_messages else 0.0
-        avg_conf = (
-            self.total_confidence / self.signatures_found if self.signatures_found else 0.0
-        )
+class MetricsCollector:
+    """Thread-safe collector for per-message metrics and aggregates."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._metrics: List[MessageMetric] = []
+        self.start_time = time.time()
+
+    def record(self, metric: MessageMetric) -> None:
+        """Store ``metric`` in the internal list."""
+        with self._lock:
+            self._metrics.append(metric)
+
+    def summarize(self) -> dict:
+        """Return aggregated metrics across all messages."""
+        with self._lock:
+            total = len(self._metrics)
+            extracted = sum(1 for m in self._metrics if m.extracted)
+            avg_time = sum(m.time_ms for m in self._metrics) / total if total else 0
+            avg_conf = sum(m.confidence for m in self._metrics) / total if total else 0
         return {
-            "messages": self.total_messages,
-            "signatures_found": self.signatures_found,
-            "avg_time_ms": round(avg_time, 2),
-            "avg_confidence": round(avg_conf, 2),
+            "total_messages": total,
+            "signatures_extracted": extracted,
+            "average_time_ms": avg_time,
+            "average_confidence": avg_conf,
+            "duration_s": time.time() - self.start_time,
         }
 
+    def dump(self, path: str) -> None:
+        """Write collected metrics and summary to ``path`` as JSON."""
+        data = {
+            "per_message": [asdict(m) for m in self._metrics],
+            "summary": self.summarize(),
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            log_message("info", f"Metrics written to {path}")
 
-def main() -> None:  # pragma: no cover - manual test
-    m = Metrics()
-    m.record("1", True, 0.8, 5, 1.2)
-    m.record("2", False, 0.0, 3, 0.5)
-    print(json.dumps(m.summary(), indent=2))
 
+# main
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":  # pragma: no cover - manual test
+    m = MetricsCollector()
+    m.record(MessageMetric("1", True, 0.9, 10))
+    time.sleep(0.01)
+    m.dump("metrics.json")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,8 +83,8 @@ def test_extract_query_export_flow(tmp_path):
     assert res.returncode == 0
     assert db.exists()
     data = json.loads(metrics.read_text())
-    assert data["messages"] == 2
-    assert data["signatures_found"] >= 2
+    assert data["summary"]["total_messages"] == 2
+    assert data["summary"]["signatures_extracted"] >= 2
     assert "Processed" in res.stdout
 
     res = _run([

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,12 +1,62 @@
-from signature_recovery.core.metrics import Metrics
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from signature_recovery.core.metrics import MetricsCollector, MessageMetric
 
 
-def test_metrics_aggregation():
-    m = Metrics()
-    m.record("1", True, 0.8, 4, 1.0)
-    m.record("2", False, 0.0, 2, 0.5)
-    summary = m.summary()
-    assert summary["messages"] == 2
-    assert summary["signatures_found"] == 1
-    assert summary["avg_confidence"] == 0.8
-    assert summary["avg_time_ms"] == 0.75
+def test_metrics_summarize():
+    mc = MetricsCollector()
+    mc.record(MessageMetric("1", True, 0.8, 50))
+    mc.record(MessageMetric("2", False, 0.0, 100))
+    summary = mc.summarize()
+    assert summary["total_messages"] == 2
+    assert summary["signatures_extracted"] == 1
+    assert summary["average_time_ms"] == 75
+    assert summary["average_confidence"] == 0.4
+
+
+def test_metrics_dump(tmp_path):
+    mc = MetricsCollector()
+    mc.record(MessageMetric("1", True, 1.0, 10))
+    out = tmp_path / "m.json"
+    mc.dump(str(out))
+    data = json.loads(out.read_text())
+    assert "per_message" in data
+    assert "summary" in data
+    assert data["summary"]["total_messages"] == 1
+
+
+def test_cli_metrics_dump(tmp_path):
+    pst = tmp_path / "dummy.pst"
+    pst.write_text("dummy")
+    db = tmp_path / "out.db"
+    metrics = tmp_path / "metrics.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{Path(__file__).parent}:{env.get('PYTHONPATH','')}"
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "signature_recovery.cli.main",
+            "--batch-size",
+            "1",
+            "--dump-metrics",
+            str(metrics),
+            "extract",
+            "--input",
+            str(pst),
+            "--index",
+            str(db),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert res.returncode == 0
+    assert metrics.exists()
+    data = json.loads(metrics.read_text())
+    assert "summary" in data
+    assert data["summary"]["total_messages"] >= 2


### PR DESCRIPTION
## Summary
- add `MetricsCollector` with per-message metrics
- integrate metrics recording & dump into CLI
- expand metrics test coverage
- mark metrics feature as In Progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f0e165c083319707e1cf84b4fb05