### PR TITLE
Refine GUI live feed: header styling, message normalization, and deduplication

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -48,8 +48,10 @@
 ### GUI
 - **Features**
   - `recover-gui` Tkinter interface (**Complete**)
+  - Live feed normalizes noisy prefixes and suppresses duplicate entries (**Complete**)
+  - Live feed uses a full-width colored header for improved tab-like visibility (**Complete**)
 - **Files**
-  - `signature_recovery/gui/app.py`
+  - `signature_recovery/gui/app.py` — search/filter/results panes, extraction workflow, and live feed formatting
   - `tests/test_recover_gui.py`
 
 ### Exporter

--- a/signature_recovery/gui/app.py
+++ b/signature_recovery/gui/app.py
@@ -261,18 +261,46 @@ class DetailPanel(tk.LabelFrame):
         self.text.config(state=tk.DISABLED)
 
 
-class AlertsPanel(tk.LabelFrame):
+class AlertsPanel(tk.Frame):
     """Display recent warning/error log messages."""
 
     def __init__(self, master: tk.Misc) -> None:
-        super().__init__(master, text="Alerts")
+        super().__init__(master)
+        self._seen_entries: set[str] = set()
+        self.header = tk.Label(
+            self,
+            text="Live Feed",
+            bg="#2b579a",
+            fg="white",
+            anchor="w",
+            padx=8,
+            pady=4,
+        )
+        self.header.pack(fill=tk.X)
         self.listbox = tk.Listbox(self, height=4)
         self.listbox.pack(fill=tk.BOTH, expand=True)
 
     def add_alert(self, msg: str) -> None:
-        self.listbox.insert(0, msg)
+        normalized = self._normalize_message(msg)
+        if normalized in self._seen_entries:
+            return
+        self._seen_entries.add(normalized)
+        self.listbox.insert(0, normalized)
         if self.listbox.size() > 100:
+            removed = self.listbox.get(100, tk.END)
             self.listbox.delete(100, tk.END)
+            for item in removed:
+                self._seen_entries.discard(item)
+
+    @staticmethod
+    def _normalize_message(msg: str) -> str:
+        """Normalize live feed text and remove noisy category prefixes."""
+        clean = " ".join(msg.split())
+        for prefix in ("System:", "Computers"):
+            clean = clean.replace(prefix, "").strip(" -:")
+        while "  " in clean:
+            clean = clean.replace("  ", " ")
+        return clean
 
 
 class _GuiLogHandler(logging.Handler):
@@ -340,7 +368,7 @@ class App(tk.Tk):
         self.alerts_panel.pack(fill=tk.BOTH, expand=False, padx=5, pady=2)
 
         handler = _GuiLogHandler(self.alerts_panel)
-        handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+        handler.setFormatter(logging.Formatter('%(message)s'))
         logging.getLogger().addHandler(handler)
 
         # Seed filter lists using all signatures in the index


### PR DESCRIPTION
### Motivation
- Improve the GUI live feed readability by removing noisy category prefixes and suppressing repeated entries. 
- Make the live feed header visually match a tab/header strip by coloring the full-width header area. 
- Ensure log-to-GUI formatting feeds clean text into the live feed normalization path. 

### Description
- Reworked the live feed widget by converting `AlertsPanel` from a `tk.LabelFrame` to a `tk.Frame` and adding a full-width colored header `Label` to present a tab-like header strip. 
- Added message normalization via `AlertsPanel._normalize_message` to strip noisy prefixes such as `System:` and `Computers` and to collapse extra whitespace. 
- Added de-duplication using a `self._seen_entries` set and removed entries from the seen set when the listbox is trimmed to maintain the bounded list. 
- Adjusted GUI log handler formatting to `'%(message)s'` so the raw message text is passed to the live feed normalization instead of including level prefixes. 
- Updated `PROJECTMAP.md` to document the live feed normalization, deduplication, and header styling changes and clarified `signature_recovery/gui/app.py` responsibilities. 

### Testing
- Attempted `pytest tests/test_recover_gui.py -q`, which failed at collection because the configured `pytest.ini` references `--timeout=300` but the environment lacks `pytest-timeout`. 
- Re-ran with `pytest -q -o addopts='' tests/test_recover_gui.py`, which failed during collection due to a missing optional GUI test dependency `pyvirtualdisplay`. 
- No automated GUI tests were executed to completion in this environment because optional test dependencies are not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036add355c83319c092c21e30b208b)