### PR TITLE
Harden GUI queue processing against handler errors

### DIFF
--- a/PROJECTMAP.md
+++ b/PROJECTMAP.md
@@ -47,10 +47,10 @@
 
 ### GUI
 - **Features**
-  - `recover-gui` Tkinter interface (**Complete**)
+  - `recover-gui` Tkinter interface with resilient queue-event handling (**Complete**)
 - **Files**
-  - `signature_recovery/gui/app.py`
-  - `tests/test_recover_gui.py`
+  - `signature_recovery/gui/app.py` — catches queue-processing exceptions and keeps UI controls responsive
+  - `tests/test_recover_gui.py` — GUI behavior tests including queue error recovery path
 
 ### Exporter
 - **Features**

--- a/signature_recovery/gui/app.py
+++ b/signature_recovery/gui/app.py
@@ -400,19 +400,31 @@ class App(tk.Tk):
         except queue.Empty:
             pass
         else:
-            if isinstance(item, tuple) and item[0] == "progress":
-                count, total = item[1], item[2]
-                self.progress_var.set(f"Processing PST {count} of {total}...")
-            elif item == "complete":
-                if hasattr(self, "progress_win"):
-                    self.progress_win.destroy()
-                self._seed_filters()
-            else:
-                results = item
-                self._display_results(results)
+            try:
+                self._handle_queue_item(item)
+            except Exception:
+                log_message("error", "Failed to process result queue item", exc_info=True)
                 self.search_panel.enable()
                 self.pagination_panel.enable()
         self.poll_id = self.after(100, self._poll_queue)
+
+    def _handle_queue_item(self, item) -> None:
+        """Handle queue events for progress, completion, and search results."""
+        if isinstance(item, tuple) and item and item[0] == "progress":
+            count, total = item[1], item[2]
+            if hasattr(self, "progress_var"):
+                self.progress_var.set(f"Processing PST {count} of {total}...")
+            return
+        if item == "complete":
+            if hasattr(self, "progress_win"):
+                self.progress_win.destroy()
+            self._seed_filters()
+            return
+
+        results = item
+        self._display_results(results)
+        self.search_panel.enable()
+        self.pagination_panel.enable()
 
     def _display_results(self, results) -> None:
         """Store and display search results, updating filter options."""

--- a/tests/test_recover_gui.py
+++ b/tests/test_recover_gui.py
@@ -154,3 +154,17 @@ def test_confidence_slider(tmp_path, display):
         time.sleep(0.05)
     assert len(app.results) == 1
     app.close()
+
+
+def test_poll_queue_recovers_from_handler_error(tmp_path, display, caplog):
+    idx = _build_index(tmp_path)
+    app = App(idx)
+    app.queue.put(object())
+
+    def boom(_item):
+        raise AttributeError("missing callback")
+
+    app._handle_queue_item = boom
+    app._poll_queue()
+    assert any("Failed to process result queue item" in r.message for r in caplog.records)
+    app.close()


### PR DESCRIPTION
### Motivation
- Prevent the GUI polling loop from stopping when an unexpected exception occurs while handling a queue item by adding defensive handling around queue event processing.
- Ensure UI controls are re-enabled after queue-processing failures so the app remains responsive even when background threads emit unexpected events.

### Description
- Refactored `App._poll_queue` to delegate work to a new helper `App._handle_queue_item` and wrapped the call in a protective `try/except` to catch runtime errors.
- Implemented `App._handle_queue_item` to handle `("progress", ...)`, `"complete"`, and result-list items with attribute checks before touching progress widgets and explicit re-enabling of `search_panel` and `pagination_panel`.
- Added a regression test `test_poll_queue_recovers_from_handler_error` in `tests/test_recover_gui.py` that injects a failing handler and asserts the error is logged without breaking polling.
- Updated `PROJECTMAP.md` to document the resilient GUI queue-event handling and the corresponding test coverage.

### Testing
- Ran `python -m compileall -q signature_recovery tests/test_recover_gui.py` and it completed successfully.
- Attempted to run the targeted GUI test with `pytest -q tests/test_recover_gui.py -k "poll_queue_recovers_from_handler_error"`, but collection failed in this environment due to a missing `pyvirtualdisplay` dependency (`ModuleNotFoundError`).
- `pytest-timeout` package installation via `python -m pip install pytest-timeout -q` completed successfully but did not affect the missing GUI test dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037790bd2883318299d5feb8c9c844)